### PR TITLE
Implement automatic release detection

### DIFF
--- a/bin/elixir-build
+++ b/bin/elixir-build
@@ -149,6 +149,12 @@ fetch_tarball() {
   echo "Downloading ${package_url}..." >&2
   { fetch_url "$package_url" > "${package_name}.tar.gz"
     tar xzvf "${package_name}.tar.gz"
+    # Handle the case where we fetch a tarball from GitHub, and
+    # it contains an innner package with the SHA1 of the release commit
+    if test -n "$(find "$BUILD_PATH" -maxdepth 1 -name 'elixir-lang-elixir-*' -print -quit)"; then
+      ls -la "$BUILD_PATH"
+      mv elixir-lang-elixir-* "$package_name"
+    fi
   } >&4 2>&1
 }
 
@@ -265,11 +271,41 @@ usage() {
   fi
 }
 
-list_definitions() {
+list_custom_definitions() {
   { for definition in "${ELIXIR_BUILD_ROOT}/share/elixir-build/"*; do
       echo "${definition##*/}"
     done
   } | sort
+}
+
+list_definitions() {
+  {
+    local items=()
+    for i in $(curl -s https://api.github.com/repos/elixir-lang/elixir/releases | ${ELIXIR_BUILD_ROOT}/bin/json | egrep '\[[0-9]+,"assets",[0-9]+,"browser_download_url"\]' | tr "\t" "\n"); do
+      items+=($i)
+    done
+
+    items_len=${#items[@]}
+    for ((i=1;i<=$items_len;i+=2)); do
+      local release_url=$(echo ${items[i]} | sed 's/\"//g')
+      echo "$(parse_release_version "$release_url")"
+    done
+  } | sort -r
+}
+
+parse_release_version() {
+  local release_url="$1"
+  echo "$(echo "$release_url" | sed 's/https\:\/\/github\.com\/elixir\-lang\/elixir\/releases\/download\/v//' | sed 's/\/Precompiled\.zip$//')"
+}
+
+is_defined() {
+  local version="$1"
+  for def in $(list_definitions); do
+    if [ "$def" == "$version" ]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 add_definition() {
@@ -300,6 +336,7 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "definitions" )
     list_definitions
+    list_custom_definitions
     exit 0
     ;;
   "add-definition" )
@@ -320,6 +357,7 @@ for option in "${OPTIONS[@]}"; do
   esac
 done
 
+IS_REMOTE_DEFINITION=0
 DEFINITION_PATH="${ARGUMENTS[0]}"
 if [ -z "$DEFINITION_PATH" ]; then
   usage
@@ -328,8 +366,17 @@ elif [ ! -e "$DEFINITION_PATH" ]; then
   if [ -e "$BUILTIN_DEFINITION_PATH" ]; then
     DEFINITION_PATH="$BUILTIN_DEFINITION_PATH"
   else
-    echo "elixir-build: definition not found: ${DEFINITION_PATH}" >&2
-    exit 1
+    # Check if there is a release with this definition
+    is_defined $DEFINITION_PATH
+    case $? in
+      0)
+        IS_REMOTE_DEFINITION=1
+        ;;
+      *)
+        echo "elixir-build: definition not found: ${DEFINITION_PATH}" >&2
+        exit 1
+        ;;
+    esac
   fi
 fi
 
@@ -365,7 +412,13 @@ unset ELIXIROPT
 unset ELIXIRLIB
 
 trap build_failed ERR
-mkdir -p "$BUILD_PATH"
-source "$DEFINITION_PATH"
+if [ $IS_REMOTE_DEFINITION -eq 1 ]; then
+  mkdir -p "$BUILD_PATH"
+  DEFINITION_NAME="${DEFINITION_PATH##*/}"
+  install_package "elixir-${DEFINITION_NAME}" "https://api.github.com/repos/elixir-lang/elixir/tarball/v${DEFINITION_NAME}"
+else
+  mkdir -p "$BUILD_PATH"
+  source "$DEFINITION_PATH"
+fi
 [ -z "${KEEP_BUILD_PATH}" ] && rm -fr "$BUILD_PATH"
 trap - ERR

--- a/bin/json
+++ b/bin/json
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+# The MIT License
+
+# Copyright (c) 2011 Dominic Tarr
+
+# Permission is hereby granted, free of charge, 
+# to any person obtaining a copy of this software and 
+# associated documentation files (the "Software"), to 
+# deal in the Software without restriction, including 
+# without limitation the rights to use, copy, modify, 
+# merge, publish, distribute, sublicense, and/or sell 
+# copies of the Software, and to permit persons to whom 
+# the Software is furnished to do so, 
+# subject to the following conditions:
+
+# The above copyright notice and this permission notice 
+# shall be included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+# ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+throw () {
+  echo "$*" >&2
+  exit 1
+}
+
+BRIEF=0
+LEAFONLY=0
+PRUNE=0
+
+usage() {
+  echo
+  echo "Usage: JSON.sh [-b] [-l] [-p] [-h]"
+  echo
+  echo "-p - Prune empty. Exclude fields with empty values."
+  echo "-l - Leaf only. Only show leaf nodes, which stops data duplication."
+  echo "-b - Brief. Combines 'Leaf only' and 'Prune empty' options."
+  echo "-h - This help text."
+  echo
+}
+
+parse_options() {
+  set -- "$@"
+  local ARGN=$#
+  while [ $ARGN -ne 0 ]
+  do
+    case $1 in
+      -h) usage
+          exit 0
+      ;;
+      -b) BRIEF=1
+          LEAFONLY=1
+          PRUNE=1
+      ;;
+      -l) LEAFONLY=1
+      ;;
+      -p) PRUNE=1
+      ;;
+      ?*) echo "ERROR: Unknown option."
+          usage
+          exit 0
+      ;;
+    esac
+    shift 1
+    ARGN=$((ARGN-1))
+  done
+}
+
+awk_egrep () {
+  local pattern_string=$1
+
+  gawk '{
+    while ($0) {
+      start=match($0, pattern);
+      token=substr($0, start, RLENGTH);
+      print token;
+      $0=substr($0, start+RLENGTH);
+    }
+  }' pattern=$pattern_string
+}
+
+tokenize () {
+  local GREP
+  local ESCAPE
+  local CHAR
+
+  if echo "test string" | egrep -ao --color=never "test" &>/dev/null
+  then
+    GREP='egrep -ao --color=never'
+  else
+    GREP='egrep -ao'
+  fi
+
+  if echo "test string" | egrep -o "test" &>/dev/null
+  then
+    ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
+    CHAR='[^[:cntrl:]"\\]'
+  else
+    GREP=awk_egrep
+    ESCAPE='(\\\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
+    CHAR='[^[:cntrl:]"\\\\]'
+  fi
+
+  local STRING="\"$CHAR*($ESCAPE$CHAR*)*\""
+  local NUMBER='-?(0|[1-9][0-9]*)([.][0-9]*)?([eE][+-]?[0-9]*)?'
+  local KEYWORD='null|false|true'
+  local SPACE='[[:space:]]+'
+
+  $GREP "$STRING|$NUMBER|$KEYWORD|$SPACE|." | egrep -v "^$SPACE$"
+}
+
+parse_array () {
+  local index=0
+  local ary=''
+  read -r token
+  case "$token" in
+    ']') ;;
+    *)
+      while :
+      do
+        parse_value "$1" "$index"
+        index=$((index+1))
+        ary="$ary""$value" 
+        read -r token
+        case "$token" in
+          ']') break ;;
+          ',') ary="$ary," ;;
+          *) throw "EXPECTED , or ] GOT ${token:-EOF}" ;;
+        esac
+        read -r token
+      done
+      ;;
+  esac
+  [ "$BRIEF" -eq 0 ] && value=`printf '[%s]' "$ary"` || value=
+  :
+}
+
+parse_object () {
+  local key
+  local obj=''
+  read -r token
+  case "$token" in
+    '}') ;;
+    *)
+      while :
+      do
+        case "$token" in
+          '"'*'"') key=$token ;;
+          *) throw "EXPECTED string GOT ${token:-EOF}" ;;
+        esac
+        read -r token
+        case "$token" in
+          ':') ;;
+          *) throw "EXPECTED : GOT ${token:-EOF}" ;;
+        esac
+        read -r token
+        parse_value "$1" "$key"
+        obj="$obj$key:$value"        
+        read -r token
+        case "$token" in
+          '}') break ;;
+          ',') obj="$obj," ;;
+          *) throw "EXPECTED , or } GOT ${token:-EOF}" ;;
+        esac
+        read -r token
+      done
+    ;;
+  esac
+  [ "$BRIEF" -eq 0 ] && value=`printf '{%s}' "$obj"` || value=
+  :
+}
+
+parse_value () {
+  local jpath="${1:+$1,}$2" isleaf=0 isempty=0 print=0
+  case "$token" in
+    '{') parse_object "$jpath" ;;
+    '[') parse_array  "$jpath" ;;
+    # At this point, the only valid single-character tokens are digits.
+    ''|[!0-9]) throw "EXPECTED value GOT ${token:-EOF}" ;;
+    *) value=$token
+       isleaf=1
+       [ "$value" = '""' ] && isempty=1
+       ;;
+  esac
+  [ "$value" = '' ] && return
+  [ "$LEAFONLY" -eq 0 ] && [ "$PRUNE" -eq 0 ] && print=1
+  [ "$LEAFONLY" -eq 1 ] && [ "$isleaf" -eq 1 ] && [ $PRUNE -eq 0 ] && print=1
+  [ "$LEAFONLY" -eq 0 ] && [ "$PRUNE" -eq 1 ] && [ "$isempty" -eq 0 ] && print=1
+  [ "$LEAFONLY" -eq 1 ] && [ "$isleaf" -eq 1 ] && \
+    [ $PRUNE -eq 1 ] && [ $isempty -eq 0 ] && print=1
+  [ "$print" -eq 1 ] && printf "[%s]\t%s\n" "$jpath" "$value"
+  :
+}
+
+parse () {
+  read -r token
+  parse_value
+  read -r token
+  case "$token" in
+    '') ;;
+    *) throw "EXPECTED EOF GOT $token" ;;
+  esac
+}
+
+if ([ "$0" = "$BASH_SOURCE" ] || ! [ -n "$BASH_SOURCE" ]);
+then
+  parse_options "$@"
+  tokenize | parse
+fi

--- a/share/elixir-build/0.10.0
+++ b/share/elixir-build/0.10.0
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-83591b9" "https://github.com/elixir-lang/elixir/tarball/v0.10.0"

--- a/share/elixir-build/0.10.1
+++ b/share/elixir-build/0.10.1
@@ -1,1 +1,0 @@
-install_package "elixir-0.10.1" "https://github.com/elixir-lang/elixir/archive/v0.10.1.tar.gz"

--- a/share/elixir-build/0.10.2
+++ b/share/elixir-build/0.10.2
@@ -1,1 +1,0 @@
-install_package "elixir-0.10.2" "https://github.com/elixir-lang/elixir/archive/v0.10.2.tar.gz"

--- a/share/elixir-build/0.10.3
+++ b/share/elixir-build/0.10.3
@@ -1,1 +1,0 @@
-install_package "elixir-0.10.3" "https://github.com/elixir-lang/elixir/archive/v0.10.3.tar.gz"

--- a/share/elixir-build/0.11.0
+++ b/share/elixir-build/0.11.0
@@ -1,1 +1,0 @@
-install_package "elixir-0.11.0" "https://github.com/elixir-lang/elixir/archive/v0.11.0.tar.gz"

--- a/share/elixir-build/0.11.1
+++ b/share/elixir-build/0.11.1
@@ -1,1 +1,0 @@
-install_package "elixir-0.11.1" "https://github.com/elixir-lang/elixir/archive/v0.11.1.tar.gz"

--- a/share/elixir-build/0.11.2
+++ b/share/elixir-build/0.11.2
@@ -1,1 +1,0 @@
-install_package "elixir-0.11.2" "https://github.com/elixir-lang/elixir/archive/v0.11.2.tar.gz"

--- a/share/elixir-build/0.12.0
+++ b/share/elixir-build/0.12.0
@@ -1,1 +1,0 @@
-install_package "elixir-0.12.0" "https://github.com/elixir-lang/elixir/archive/v0.12.0.tar.gz"

--- a/share/elixir-build/0.12.1
+++ b/share/elixir-build/0.12.1
@@ -1,1 +1,0 @@
-install_package "elixir-0.12.1" "https://github.com/elixir-lang/elixir/archive/v0.12.1.tar.gz"

--- a/share/elixir-build/0.12.2
+++ b/share/elixir-build/0.12.2
@@ -1,1 +1,0 @@
-install_package "elixir-0.12.2" "https://github.com/elixir-lang/elixir/archive/v0.12.2.tar.gz"

--- a/share/elixir-build/0.12.3
+++ b/share/elixir-build/0.12.3
@@ -1,1 +1,0 @@
-install_package "elixir-0.12.3" "https://github.com/elixir-lang/elixir/archive/v0.12.3.tar.gz"

--- a/share/elixir-build/0.12.4
+++ b/share/elixir-build/0.12.4
@@ -1,1 +1,0 @@
-install_package "elixir-0.12.4" "https://github.com/elixir-lang/elixir/archive/v0.12.4.tar.gz"

--- a/share/elixir-build/0.12.5
+++ b/share/elixir-build/0.12.5
@@ -1,1 +1,0 @@
-install_package "elixir-0.12.5" "https://github.com/elixir-lang/elixir/archive/v0.12.5.tar.gz"

--- a/share/elixir-build/0.13.0
+++ b/share/elixir-build/0.13.0
@@ -1,1 +1,0 @@
-install_package "elixir-0.13.0" "https://github.com/elixir-lang/elixir/archive/v0.13.0.tar.gz"

--- a/share/elixir-build/0.13.1
+++ b/share/elixir-build/0.13.1
@@ -1,1 +1,0 @@
-install_package "elixir-0.13.1" "https://github.com/elixir-lang/elixir/archive/v0.13.1.tar.gz"

--- a/share/elixir-build/0.13.2
+++ b/share/elixir-build/0.13.2
@@ -1,1 +1,0 @@
-install_package "elixir-0.13.2" "https://github.com/elixir-lang/elixir/archive/v0.13.2.tar.gz"

--- a/share/elixir-build/0.13.3
+++ b/share/elixir-build/0.13.3
@@ -1,1 +1,0 @@
-install_package "elixir-0.13.3" "https://github.com/elixir-lang/elixir/archive/v0.13.3.tar.gz"

--- a/share/elixir-build/0.14.0
+++ b/share/elixir-build/0.14.0
@@ -1,1 +1,0 @@
-install_package "elixir-0.14.0" "https://github.com/elixir-lang/elixir/archive/v0.14.0.tar.gz"

--- a/share/elixir-build/0.14.1
+++ b/share/elixir-build/0.14.1
@@ -1,1 +1,0 @@
-install_package "elixir-0.14.1" "https://github.com/elixir-lang/elixir/archive/v0.14.1.tar.gz"

--- a/share/elixir-build/0.14.2
+++ b/share/elixir-build/0.14.2
@@ -1,1 +1,0 @@
-install_package "elixir-0.14.2" "https://github.com/elixir-lang/elixir/archive/v0.14.2.tar.gz"

--- a/share/elixir-build/0.5.0
+++ b/share/elixir-build/0.5.0
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-6052352" "https://github.com/elixir-lang/elixir/tarball/v0.5.0"

--- a/share/elixir-build/0.6.0
+++ b/share/elixir-build/0.6.0
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-8d543cd" "https://github.com/elixir-lang/elixir/tarball/v0.6.0"

--- a/share/elixir-build/0.7.0
+++ b/share/elixir-build/0.7.0
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-833e9e9" "https://github.com/elixir-lang/elixir/tarball/v0.7.0"

--- a/share/elixir-build/0.7.1
+++ b/share/elixir-build/0.7.1
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-8cede65" "https://github.com/elixir-lang/elixir/tarball/v0.7.1"

--- a/share/elixir-build/0.7.2
+++ b/share/elixir-build/0.7.2
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-243433d" "https://github.com/elixir-lang/elixir/tarball/v0.7.2"

--- a/share/elixir-build/0.8.0
+++ b/share/elixir-build/0.8.0
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-437adc1" "https://github.com/elixir-lang/elixir/tarball/v0.8.0"

--- a/share/elixir-build/0.8.1
+++ b/share/elixir-build/0.8.1
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-90ff71b" "https://github.com/elixir-lang/elixir/tarball/v0.8.1"

--- a/share/elixir-build/0.8.2
+++ b/share/elixir-build/0.8.2
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-ed27611" "https://github.com/elixir-lang/elixir/tarball/v0.8.2"

--- a/share/elixir-build/0.8.3
+++ b/share/elixir-build/0.8.3
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-59d6448" "https://github.com/elixir-lang/elixir/tarball/v0.8.3"

--- a/share/elixir-build/0.9.0
+++ b/share/elixir-build/0.9.0
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-91e8e21" "https://github.com/elixir-lang/elixir/tarball/v0.9.0"

--- a/share/elixir-build/0.9.1
+++ b/share/elixir-build/0.9.1
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-24c6623" "https://github.com/elixir-lang/elixir/tarball/v0.9.1"

--- a/share/elixir-build/0.9.2
+++ b/share/elixir-build/0.9.2
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-a613445" "https://github.com/elixir-lang/elixir/tarball/v0.9.2"

--- a/share/elixir-build/0.9.3
+++ b/share/elixir-build/0.9.3
@@ -1,1 +1,0 @@
-install_package "elixir-lang-elixir-32d4739" "https://github.com/elixir-lang/elixir/tarball/v0.9.3"


### PR DESCRIPTION
This PR solves the problem of requiring release definition files. Now when you install a release via `exenv install <version>`, it will first check for a matching local custom definition, and if one is not found, then it will query the GitHub API for known releases, if a match is found in the list of releases, it will install via the tarball.

This means that as soon as a new Elixir release is published to GitHub, users of exenv/elixir-build can immediately install that release via `exenv install`. Furthermore, one could easily implement an `exenv install latest` option that takes advantage of the fact that we can pull the latest releases from GitHub.

Questions/comments welcome!
